### PR TITLE
Add new local mongo provision script for authenticated usage.

### DIFF
--- a/conf/load_variables.sh
+++ b/conf/load_variables.sh
@@ -1,6 +1,7 @@
 # default values
 SERVER=104.199.132.136
 APP_DIR=/var/www/hellogov
+LOCAL_APP_DIR=$(pwd)
 ARCHIVE_DIR=/home/hellogov/archive
 GIT_URL="git://github.com/helloGov/singleAction"
 GIT_DEPLOY_URL="git://github.com/helloGov/deploy"

--- a/conf/mongod.conf
+++ b/conf/mongod.conf
@@ -6,7 +6,7 @@ storage:
 systemLog:
   destination: file
   logAppend: true
-  path: usr/local/var/log/mongodb/mongo.log
+  path: /usr/local/var/log/mongodb/mongo.log
 
 net:
   port: 27018

--- a/conf/mongod.conf
+++ b/conf/mongod.conf
@@ -1,15 +1,15 @@
 storage:
-  dbPath: /var/lib/mongodb
+  dbPath: /data/db
   journal:
     enabled: true
 
 systemLog:
   destination: file
   logAppend: true
-  path: /var/log/mongodb/mongod.log
+  path: usr/local/var/log/mongodb/mongo.log
 
 net:
-  port: 27017
+  port: 27018
   ssl:
     mode: requireSSL
     PEMKeyFile: /etc/ssl/mongodb.pem
@@ -17,4 +17,3 @@ net:
 
 security:
   authorization: enabled
-

--- a/provision_mongo_local.sh
+++ b/provision_mongo_local.sh
@@ -1,0 +1,26 @@
+# # expects a firewall rule opening port 27018 to application servers
+source `pwd`/conf/load_variables.sh
+source `pwd`/conf/secrets.sh
+
+# Setup database directory
+sudo mkdir -p /data/db
+sudo chmod -R 757 /data/db
+
+# Stop an existing mongo instance
+pgrep mongod | xargs kill -2
+
+# Create admin user
+mongod --port 27018 --dbpath /data/db --fork --logpath /usr/local/var/log/mongodb/mongod.log
+mongo localhost:27018/admin --eval "db.createUser({user:'$DB_ADMIN_USER',pwd:'$DB_ADMIN_PASSWORD',roles:[{role:'userAdminAnyDatabase',db:'admin'}, 'readWriteAnyDatabase']})"
+
+# Install TLS certificate, configure mongo to use it
+cd /etc/ssl/
+sudo openssl req -newkey rsa:2048 -new -x509 -days 365 -nodes -out mongodb-cert.crt -keyout mongodb-cert.key -subj "/C=US/ST=California/L=San Francisco/O=helloGov/OU=Engineering/CN=data.hellogov.org"
+sudo sh -c "cat mongodb-cert.key mongodb-cert.crt > mongodb.pem"
+sudo scp mongodb.pem /tmp/mongodb.pem
+sudo cp -r $(pwd)/conf/mongod.conf /etc
+
+#Test secure connections by creating application user
+pgrep mongod | xargs kill -2
+mongod --config /etc/mongod.conf --auth --port 27018 --dbpath /data/db --fork --logpath /usr/local/var/log/mongodb/mongod.log
+mongo localhost:27018/hellogov -u $DB_ADMIN_USER -p $DB_ADMIN_PASSWORD --authenticationDatabase "admin" --ssl --sslAllowInvalidHostnames --sslCAFile /etc/ssl/mongodb.pem --eval "db.createUser({user:'$DB_USER',pwd:'$DB_PASSWORD',roles:[{role:'readWrite',db:'hellogov'}]});"

--- a/provision_mongo_local.sh
+++ b/provision_mongo_local.sh
@@ -1,10 +1,10 @@
-# # expects a firewall rule opening port 27018 to application servers
+# expects a firewall rule opening port 27018 to application servers
 source `pwd`/conf/load_variables.sh
 source `pwd`/conf/secrets.sh
 
 # Setup database directory
 sudo mkdir -p /data/db
-sudo chmod -R 646 /data/db
+sudo chmod -R 757 /data/db
 
 # Stop an existing mongo instance
 pgrep mongod | xargs kill -2
@@ -18,9 +18,9 @@ cd /etc/ssl/
 sudo openssl req -newkey rsa:2048 -new -x509 -days 365 -nodes -out mongodb-cert.crt -keyout mongodb-cert.key -subj "/C=US/ST=California/L=San Francisco/O=helloGov/OU=Engineering/CN=data.hellogov.org"
 sudo sh -c "cat mongodb-cert.key mongodb-cert.crt > mongodb.pem"
 sudo scp mongodb.pem /tmp/mongodb.pem
-sudo cp -r $(pwd)/conf/mongod.conf /etc
+sudo cp -r "$LOCAL_APP_DIR/conf/mongod.conf" /etc
 
-#Test secure connections by creating application user
+# Test secure connections by creating application user
 pgrep mongod | xargs kill -2
 mongod --config /etc/mongod.conf --auth --port 27018 --dbpath /data/db --fork --logpath /usr/local/var/log/mongodb/mongod.log
 mongo localhost:27018/hellogov -u $DB_ADMIN_USER -p $DB_ADMIN_PASSWORD --authenticationDatabase "admin" --ssl --sslAllowInvalidHostnames --sslCAFile /etc/ssl/mongodb.pem --eval "db.createUser({user:'$DB_USER',pwd:'$DB_PASSWORD',roles:[{role:'readWrite',db:'hellogov'}]});"

--- a/provision_mongo_local.sh
+++ b/provision_mongo_local.sh
@@ -4,7 +4,7 @@ source `pwd`/conf/secrets.sh
 
 # Setup database directory
 sudo mkdir -p /data/db
-sudo chmod -R 757 /data/db
+sudo chmod -R 646 /data/db
 
 # Stop an existing mongo instance
 pgrep mongod | xargs kill -2


### PR DESCRIPTION
This PR adds an updated version of the `provision_mongo` script to the deploy repo. Developers should be able to run this script and end up with both an admin user, which acts as a superadmin, and a sample user created using the admin's authentication credentials.

Note, this is for local use only. And to use this script, make sure that you have environment variables set for:

- DB_ADMIN_USER
- DB_ADMIN_PASSWORD
- DB_USER
- DB_PASSWORD

> Remember, that if you are using a secret file, to not check it into version control

